### PR TITLE
Initial release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+image_cache
+package-lock.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Michael Schmidt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Seeing that photos come in all shapes & sizes, the `imagesPerRow` setting doesn'
 
 ## Row Types
 
-The `rowType` option is by default set to `wife` - which means that your first row of photos will be the newest photos you've uploaded and any other rows will be random images pulled from your total pool of photos. It is named this way because, well, that's what my wife wanted. Your other options are 'newest' (all images are shown in chronological order) or `random` (all images are shown in random order).
+The `rowType` option is by default set to `wife` - which means that your first row of photos will be the newest photos you've uploaded and any other rows will be random images pulled from your total pool of photos. It is named this way because, well, that's what my wife wanted. Your other options are `newest` (all images are shown in chronological order) or `random` (all images are shown in random order).
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -1,1 +1,95 @@
-# mmm-dropbox
+# Module: mmm-dropbox
+
+The `mmm-dropbox` module is a [MagicMirror](https://github.com/MichMich/MagicMirror) addon.
+
+This module takes images from a [Dropbox](https://www.dropbox.com) folder, scales & formats them nicely, and then displays them in organized rows on your Magic Mirror.
+
+This module has a very specific target audience - my wife. She wanted an easy way for her & our daughter to upload photos of our cat to Dropbox and then see them on her mirror. So ... if you're looking for a module with endless configurations, tons of design options and the ability to handle videos, well, this isn't it. Sorry.
+
+What this module does allow you to do, however, is to:
+- pick a Dropbox folder to load images (`.jpg`, `.jpeg`, `.gif` and `.png`) from
+- control how many rows of images you'd like to see
+- control the base number of images you'd like to see per row
+- select whether the images are randomly sorted or displayed newest first
+- gaze in amazement at endless cat photos nicely lined up next to each other
+
+![image](https://user-images.githubusercontent.com/3209660/50133914-5437e080-0253-11e9-90dd-681a31c68a71.png)
+*An example of this module using the default configuration.*
+
+
+## Installing the module
+
+1) Run `git clone https://github.com/michael5r/mmm-dropbox.git` from inside your `MagicMirror/modules` folder.
+2) Run `cd mmm-nest-status` in the same terminal window, then `npm install` to install the required Node modules.
+
+
+## Getting the Dropbox Access Token
+In order for you to access your Dropbox folder through your mirror, you need a [Dropbox developer account](https://www.dropbox.com/developers) and to set up a simple Dropbox app.
+
+- go to the site above and either login with your existing Dropbox user or create a new one
+- click the `Create App` button
+- choose the `Dropbox API`
+- choose the type of access you want (either will work)
+- name your app
+- click `Create App`
+
+On the next page, look for the area where it says `Generated access token` and click `Generate` underneath it. Copy that token and add it to the configuration settings of this module.
+
+
+## Using the module
+To use this module, simply add it to the `modules` array in the MagicMirror `config/config.js` file:
+
+```js
+{
+    module: 'mmm-dropbox',
+    position: 'bottom_bar', // pick whichever position you want
+    config: {
+        token: <DROPBOX_ACCESS_TOKEN>,
+        folder: <DROPBOX_FOLDER_NAME>,
+        // ... and whatever else configuration options you want to use
+    }
+},
+```
+
+
+## General Configuration Options
+
+Option               | Type      | Default   | Description
+---------------------|-----------|-----------|-------------------------------------------------------------
+`token`              | `string`  | -         | **This value is required for this module to work.**
+`folder`             | `string`  | -         | Which Dropbox folder to pull images from. [Read more](#folder)
+`imagesPerRow`       | `int`     | `4`       | Base number of images per row. [Read more](#images-per-row)
+`imagesMargin`       | `int`     | `10`      | How much blank space you want around the images. Default is 10px.
+`numberOfRows`       | `int`     | `2`       | How many rows of images you wish to display.
+`rowType`            | `string`  | 'wife'    | One of: 'wife', 'newest', 'random'. [Read more](#row-types)
+`dataUpdateInterval` | `int`     | `2.16e+7` | How often to load new data from Dropbox, default is every 6 hours.
+`updateInterval`     | `int`     | `300000`  | How often to refresh your photos on the mirror, default is every 5 minutes.
+`initialLoadDelay`   | `int`     | `0`       | How long to delay the initial load (in ms)
+
+
+## Folder
+
+If you set the `folder` option blank, your images will be pulled from the root of your `Dropbox` account. If you'd rather have a specific folder to pull images from, create a new Dropbox folder and add the name to the `folder` setting.
+
+
+## Images Per Row
+
+Seeing that photos come in all shapes & sizes, the `imagesPerRow` setting doesn't guarantee that you'll get exactly that number of images shown per row (because it would be impossible to line things up nicely that way). You should think of this setting as your baseline - meaning that if you set it to `4`, you could potentially get 3, 4, or 5 images per row, depending on whether they're landscape or portrait photos, but, if possible, you will get 4.
+
+
+## Row Types
+
+The `rowType` option is by default set to `wife` - which means that your first row of photos will be the newest photos you've uploaded and any other rows will be random images pulled from your total pool of photos. It is named this way because, well, that's what my wife wanted. Your other options are 'newest' (all images are shown in chronological order) or `random` (all images are shown in random order).
+
+
+## FAQ
+
+### Why is the dataUpdateInterval set to 6 hours? That seems long ...
+
+This module grabs up to 200 images from Dropbox every time it does a data pull, so it didn't seem necessary to get data that often. Feel free to change it if you have an urgent desire to get new images non-stop.
+
+Don't confuse this setting with `updateInterval`, though - the `updateInterval` setting (which, by default, is set to 5 minutes) selects how often you want your mirror to show new images.
+
+### Even with the rowType set to newest, I'm still seeing old photos.
+
+If possible, this module will try to read the metadata of your photo to determine when it was actually taken. However, whether your photo has this metadata or not depends entirely on the camera or phone you used to take the photo with (and the security settings of said device). As such, if the metadata cannot be found, the module will default to using the date & time the image was uploaded to Dropbox instead.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ To use this module, simply add it to the `modules` array in the MagicMirror `con
     module: 'mmm-dropbox',
     position: 'bottom_bar', // pick whichever position you want
     config: {
-        token: <DROPBOX_ACCESS_TOKEN>,
-        folder: <DROPBOX_FOLDER_NAME>,
+        token: '<DROPBOX_ACCESS_TOKEN>',
+        folder: '<DROPBOX_FOLDER_NAME>',
         // ... and whatever else configuration options you want to use
     }
 },
@@ -57,11 +57,11 @@ To use this module, simply add it to the `modules` array in the MagicMirror `con
 Option               | Type      | Default   | Description
 ---------------------|-----------|-----------|-------------------------------------------------------------
 `token`              | `string`  | -         | **This value is required for this module to work.**
-`folder`             | `string`  | -         | Which Dropbox folder to pull images from. [Read more](#folder)
+`folder`             | `string`  |           | Which Dropbox folder to pull images from. [Read more](#folder)
 `imagesPerRow`       | `int`     | `4`       | Base number of images per row. [Read more](#images-per-row)
-`imagesMargin`       | `int`     | `10`      | How much blank space you want around the images. Default is 10px.
+`imagesMargin`       | `int`     | `10`      | How much blank space you want around the images in pixels.
 `numberOfRows`       | `int`     | `2`       | How many rows of images you wish to display.
-`rowType`            | `string`  | 'wife'    | One of: 'wife', 'newest', 'random'. [Read more](#row-types)
+`rowType`            | `string`  | `wife`    | One of: 'wife', 'newest', 'random'. [Read more](#row-types)
 `dataUpdateInterval` | `int`     | `2.16e+7` | How often to load new data from Dropbox, default is every 6 hours.
 `updateInterval`     | `int`     | `300000`  | How often to refresh your photos on the mirror, default is every 5 minutes.
 `initialLoadDelay`   | `int`     | `0`       | How long to delay the initial load (in ms)
@@ -74,7 +74,9 @@ If you set the `folder` option blank, your images will be pulled from the root o
 
 ## Images Per Row
 
-Seeing that photos come in all shapes & sizes, the `imagesPerRow` setting doesn't guarantee that you'll get exactly that number of images shown per row (because it would be impossible to line things up nicely that way). You should think of this setting as your baseline - meaning that if you set it to `4`, you could potentially get 3, 4, or 5 images per row, depending on whether they're landscape or portrait photos, but, if possible, you will get 4.
+Seeing that photos come in all shapes & sizes, the `imagesPerRow` setting doesn't guarantee that you'll get exactly that number of images shown per row (because it would be impossible to line things up nicely that way).
+
+You should think of this setting as your baseline - meaning that if you set it to `4`, you could potentially get 3, 4, or 5 images per row, depending on whether they're landscape or portrait photos, but, if possible, you will get 4.
 
 
 ## Row Types

--- a/mmm-dropbox.css
+++ b/mmm-dropbox.css
@@ -1,0 +1,12 @@
+.mmm-dropbox .inner {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.mmm-dropbox .inner img {
+    display: block;
+    border-radius: 5px;
+    overflow: hidden;
+}

--- a/mmm-dropbox.js
+++ b/mmm-dropbox.js
@@ -1,0 +1,390 @@
+/* global Module */
+
+/* Magic Mirror
+ * Module: mmm-dropbox
+ *
+ * By Michael Schmidt
+ * https://github.com/michael5r
+ *
+ * MIT Licensed.
+ */
+
+Module.register('mmm-dropbox', {
+
+    defaults: {
+        token: '',                              // dropbox access token
+        folder: '',                             // which folder to be scanned, defaults to root
+        imagesPerRow: 4,                        // base number of images pr. row
+        imagesMargin: 10,                       // eg. 10px
+        numberOfRows: 2,                        // how many rows of images to show
+        rowType: 'wife',                        // how to sort images in every row
+        dataUpdateInterval: 6 * 60 * 60 * 1000, // every 6 hours
+        updateInterval: 5 * 60 * 1000,          // every 5 minutes
+        animationSpeed: 2 * 1000,
+        initialLoadDelay: 0,
+        version: '1.0.0'
+    },
+
+    getStyles: function() {
+        return [
+            'mmm-dropbox.css'
+        ];
+    },
+
+    start: function() {
+
+        Log.info('Starting module: ' + this.name + ', version ' + this.config.version);
+
+        this.errMsg = '';
+
+        this.loaded = false;
+        this.scheduleUpdate(this.config.initialLoadDelay);
+
+        this.files = [];
+
+    },
+
+    getDom: function() {
+
+        var outer_wrapper = document.createElement('div');
+
+        // show error message
+        if (this.errMsg !== '') {
+            outer_wrapper.innerHTML = this.errMsg;
+            outer_wrapper.className = 'normal regular small';
+            return outer_wrapper;
+        }
+
+        // show loading message
+        if (!this.loaded) {
+            outer_wrapper.innerHTML = 'Loading ...';
+            outer_wrapper.className = 'bright light small';
+            return outer_wrapper;
+        }
+
+        if ((this.loaded) && (this.files.length > 0)) {
+            outer_wrapper.className = 'dropbox-wrapper';
+            var view = this.renderView();
+            outer_wrapper.appendChild(view);
+        }
+
+        return outer_wrapper;
+
+    },
+
+    getData: function() {
+        this.sendSocketNotification('MMM_DROPBOX_GET');
+    },
+
+    notificationReceived(notification, payload, sender) {
+
+        if (notification === 'DOM_OBJECTS_CREATED') {
+            if (this.config.token === '') {
+                this.errMsg = 'Please add your Dropbox token to the MagicMirror config.js file.';
+                this.updateDom(this.config.animationSpeed);
+            } else {
+                this.sendSocketNotification('MMM_DROPBOX_INIT', this.config);
+            }
+        }
+
+    },
+
+    socketNotificationReceived: function(notification, payload) {
+
+        if (notification === 'MMM_DROPBOX_FILES') {
+            if (payload.length > 0) {
+
+                // TODO add dropbox data getter interval
+
+                // only use files that have been saved
+                var savedFiles = payload.filter(function(obj) { return obj.saved; });
+
+                // sort the files based on time taken
+                if (savedFiles.length > 0) {
+                    savedFiles.sort((a, b) => b.time_taken.localeCompare(a.time_taken));
+                    this.files = savedFiles;
+                }
+
+                this.loaded = true;
+
+            }
+            this.updateDom(this.config.animationSpeed);
+        } else if (notification === 'MMM_DROPBOX_ERROR') {
+            this.errMsg = payload;
+            this.updateDom(this.config.animationSpeed);
+        }
+
+    },
+
+    renderView: function() {
+
+        var outerWrapper = document.createElement('div');
+
+        var files = this.files;
+        var filesRandom = files.slice(0);
+        filesRandom.sort(function() { return Math.random() - 0.5; });
+
+        var numberOfRows = parseInt(this.config.numberOfRows) > 1 ? parseInt(this.config.numberOfRows) : 1; // we always want one row
+        var rowType = this.config.rowType;
+
+        if ((rowType !== 'newest') && (rowType !== 'random') && (rowType !== 'wife')) {
+            rowType = 'wife';
+        }
+
+        var filesOffset = 0;
+
+        for (var i = 0; i < numberOfRows; i++) {
+
+            if (rowType === 'newest') {
+
+                var row = this.getRow(files,i,filesOffset);
+                if (row) {
+                    outerWrapper.appendChild(row.row);
+                    filesOffset += 1 + row.offset;
+                }
+
+
+            } else if (rowType === 'random') {
+
+                var row = this.getRow(filesRandom,i,filesOffset);
+                if (row) {
+                    outerWrapper.appendChild(row.row);
+                    filesOffset += 1 + row.offset;
+                }
+
+            } else {
+                // wife mode
+
+                if (i === 0) {
+
+                    var row = this.getRow(files,i,0);
+                    if (row) {
+                        outerWrapper.appendChild(row.row);
+                        filesOffset += 1 + row.offset;
+                    }
+
+                } else {
+
+                    if (i === 1) {
+                        filesRandom = files.slice(filesOffset);
+                        filesRandom.sort(function() { return Math.random() - 0.5; });
+                        filesOffset = 0;
+                    }
+
+                    var row = this.getRow(filesRandom,i,filesOffset);
+                    if (row) {
+                        outerWrapper.appendChild(row.row);
+                        filesOffset += 1 + row.offset;
+                    }
+
+                }
+
+            }
+        }
+
+        return outerWrapper;
+
+    },
+
+    getRow: function(files, pos, start) {
+
+        /*
+            We're using the w480h320 size with the strict mode for the thumbnails.
+
+            What this means is that images will most likely be scaled down to a 320px height with a 480px-or-less width,
+            but they can also be scaled down to a 480px width (if the image is very narrow) with a 320px-or-less height.
+
+            Default portrait images end up a 240px (w) x 320px (h) image - we use this ratio to calculate stuff with.
+
+            Based on imagesPerRow, imagesMargin and the outer width of the container, we can then calculate the height images need to be set to in order to ensure
+            that either X, X-1 or X+1 number of images fit in a row.
+
+        */
+
+        if ((files.length < 1) || (files.length < start)) {
+            return false;
+        }
+
+        var row = document.createElement('div');
+
+        var images = [];
+        var imagesPerRow = parseInt(this.config.imagesPerRow);
+        var imagesPerRowPlus = imagesPerRow + 1;
+        var imagesPerRowMinus = imagesPerRow > 1 ? imagesPerRow - 1 : 1;
+        var imagesMargin = parseInt(this.config.imagesMargin);
+        var outerWidth = document.querySelector('.module.mmm-dropbox .module-content').offsetWidth; // 960
+        var baseHeightToWidthRatio = ((100/240) * 320) / 100; // 1.3333
+
+        // calculate the height that images should be if we were to fit X number of
+        // default portrait images into a single row
+        var baseWidth = (outerWidth - ((imagesMargin * 2) * (imagesPerRow-1))) / imagesPerRow;
+        var baseHeight = baseHeightToWidthRatio * baseWidth;
+
+        // do the same for imagesPerRow + 1
+        var basePlusWidth = (outerWidth - ((imagesMargin * 2) * (imagesPerRowPlus-1))) / imagesPerRowPlus;
+        var basePlusHeight = baseHeightToWidthRatio * basePlusWidth;
+
+        // and imagesPerRow - 1
+        var baseMinusWidth = (outerWidth - ((imagesMargin * 2) * (imagesPerRowMinus-1))) / imagesPerRowMinus;
+        var baseMinusHeight = baseHeightToWidthRatio * baseMinusWidth;
+
+        var totalW = 0 - (imagesMargin * 2); // because the left and right margins will be absorbed by the outher container
+        var totalPlusW = totalW;
+        var totalMinusW = totalW;
+        var offsetMod = 0; // in case we remove images
+
+        for (var i = start; i < files.length; i++) {
+
+            var file = files[i];
+            var fileW = file.width;
+            var fileH = file.height;
+            var portrait = fileH > fileW;
+
+            // only show image if it has a width or height property
+            if ((fileW > 0) && (fileH > 0)) {
+
+                // figure out the size ratio between width & height
+                // for portrait this is > 1.00, for landscape this is < 1.00
+                // var fileHeightToWidthRatio = ((100/fileW) * fileH / 100);
+
+                // figure out what the width of this file would be if it's using the various heights
+                var fileScaledW = Math.floor(fileW / (fileH / baseHeight));
+                var filePlusScaledW = Math.floor(fileW / (fileH / basePlusHeight));
+                var fileMinusScaledW = Math.floor(fileW / (fileH / baseMinusHeight));
+
+                // push values
+                totalW += (fileScaledW + (2 * imagesMargin));
+                totalPlusW += (filePlusScaledW + (2 * imagesMargin));
+                totalMinusW += (fileMinusScaledW + (2 * imagesMargin));
+
+                // push to temp array
+                images.push({
+                    name: file.name,
+                    base: totalW <= (outerWidth + fileScaledW + (2 * imagesMargin)),
+                    plus: totalPlusW <= (outerWidth + filePlusScaledW + (2 * imagesMargin)),
+                    minus: totalMinusW <= (outerWidth + fileMinusScaledW + (2 * imagesMargin)),
+                    w: fileW,
+                    h: fileH
+                });
+
+                if ((totalW > outerWidth) && (totalPlusW > outerWidth) && (totalMinusW > outerWidth)) {
+                    // we've found the images we needed
+                    break;
+                }
+
+            } else {
+                offsetMod++;
+            }
+
+        }
+
+        // figure out which model is closest to the outerWidth size
+        var closest = [totalW, totalPlusW, totalMinusW].reduce(function(prev, curr) {
+            return (Math.abs(curr - outerWidth) < Math.abs(prev - outerWidth) ? curr : prev);
+        });
+
+        var offset = 0;
+        var imgModel = 'base';
+        var imgHeight = baseHeight;
+
+        if (closest === totalPlusW) {
+            imgModel = 'plus';
+            imgHeight = basePlusHeight;
+        } else if (closest === totalMinusW) {
+            imgModel = 'minus';
+            imgHeight = baseMinusHeight;
+        }
+
+        // we need to know how many images we'll actually end up showing
+        var imagesToBeShown = 0;
+        for (var j = 0; j < images.length; j++) {
+            var image = images[j];
+            if ((imgModel === 'base' && image.base) || (imgModel === 'plus' && image.plus) || (imgModel === 'minus' && image.minus)) {
+                imagesToBeShown++;
+            }
+        }
+
+        var rowRealWidth = 0;
+        var rowFull = true;
+
+        if (closest > outerWidth) {
+            // need to reduce the height of the images to make them fit
+            var marginModifier = (imagesToBeShown - 1) * (imagesMargin * 2);
+            var heightModifier = (100/(closest - marginModifier) * (outerWidth - marginModifier)) / 100;
+            imgHeight = Math.floor(imgHeight * heightModifier);
+        } else if (closest < outerWidth) {
+            // we don't have enough images to fill up this row
+            rowFull = false;
+            imgHeight = Math.floor(imgHeight);
+        } else {
+            imgHeight = Math.floor(imgHeight);
+        }
+
+        // loop through array again
+        for (var j = 0; j < images.length; j++) {
+
+            var image = images[j];
+
+            if ((imgModel === 'base' && image.base) || (imgModel === 'plus' && image.plus) || (imgModel === 'minus' && image.minus)) {
+
+                // due to the images only being scaled in one direction, there's a good chance we'll end up being off
+                // on the row width by a couple of pixels - let's fix this, so everything lines up nicely
+
+                var imgRealWidth = Math.ceil(((100/image.h * imgHeight) / 100) * image.w);
+                rowRealWidth += imgRealWidth;
+
+                if ((j === (images.length - 1)) && (rowFull)) {
+                    // we're on the last image
+                    rowRealWidth = rowRealWidth + ((imagesToBeShown - 1) * (imagesMargin * 2));
+                    if (rowRealWidth < outerWidth) {
+                        imgRealWidth = imgRealWidth + (outerWidth - rowRealWidth);
+                    } else if (rowRealWidth > outerWidth) {
+                        imgRealWidth = imgRealWidth - (rowRealWidth - outerWidth);
+                    }
+                }
+
+                var img = document.createElement('img');
+                img.setAttribute('src', 'modules/mmm-dropbox/image_cache/' + image.name);
+                img.setAttribute('style', 'margin: ' + imagesMargin + 'px; height: ' + Math.floor(imgHeight) + 'px; width: ' + imgRealWidth + 'px;');
+                row.appendChild(img);
+                offset = j;
+
+            }
+
+        }
+
+        // set row attributes
+        var rowMarginMod = pos > 0 ? ' margin-top: ' + (2 * imagesMargin) + 'px;' : '';
+        row.className = 'inner row-' + pos;
+        row.setAttribute('style','height: ' + (Math.floor(imgHeight) + imagesMargin) + 'px; margin: ' + (0 - imagesMargin) + 'px;' + rowMarginMod);
+        offset = offset + offsetMod;
+
+        return {
+            row,
+            offset
+        };
+
+    },
+
+    isString: function(val) {
+        return typeof val === 'string' || val instanceof String;
+    },
+
+    isArray: function(val) {
+        return Array.isArray(val);
+    },
+
+    scheduleUpdate: function(delay) {
+
+        var nextLoad = this.config.updateInterval;
+        if (typeof delay !== 'undefined' && delay >= 0) {
+            nextLoad = delay;
+        }
+
+        var self = this;
+        setTimeout(function() {
+            self.getData();
+        }, nextLoad);
+    }
+
+});

--- a/mmm-dropbox.js
+++ b/mmm-dropbox.js
@@ -92,9 +92,8 @@ Module.register('mmm-dropbox', {
     socketNotificationReceived: function(notification, payload) {
 
         if (notification === 'MMM_DROPBOX_FILES') {
-            if (payload.length > 0) {
 
-                // TODO add dropbox data getter interval
+            if (payload.length > 0) {
 
                 // only use files that have been saved
                 var savedFiles = payload.filter(function(obj) { return obj.saved; });
@@ -103,12 +102,14 @@ Module.register('mmm-dropbox', {
                 if (savedFiles.length > 0) {
                     savedFiles.sort((a, b) => b.time_taken.localeCompare(a.time_taken));
                     this.files = savedFiles;
+                    if (!this.loaded) {
+                        this.loaded = true;
+                    }
                 }
-
-                this.loaded = true;
-
             }
+
             this.updateDom(this.config.animationSpeed);
+
         } else if (notification === 'MMM_DROPBOX_ERROR') {
             this.errMsg = payload;
             this.updateDom(this.config.animationSpeed);

--- a/node_helper.js
+++ b/node_helper.js
@@ -32,9 +32,6 @@ module.exports = NodeHelper.create({
             fs.mkdirSync(IMG_FOLDER);
         }
 
-        // we only want to pull fresh dropbox data every 12 hours
-        this.lastDataPull = Date.now();
-        this.lastDataPullError = false;
     },
 
     getData: function() {
@@ -42,6 +39,10 @@ module.exports = NodeHelper.create({
 
         if (this.timer) {
             clearTimeout(this.timer);
+        }
+
+        if (this.dataTimer) {
+            clearTimeout(this.dataTimer);
         }
 
         const self = this;
@@ -139,6 +140,15 @@ module.exports = NodeHelper.create({
     },
 
     sortData: function() {
+
+        var self = this;
+
+        if (!this.dataTimer) {
+            // set time for next data call
+            this.dataTimer = setTimeout(() => {
+                self.getData();
+            }, self.config.dataUpdateInterval);
+        }
 
         // sort this.files based on time_taken property (newest first)
         this.files.sort((a, b) => b.time_taken.localeCompare(a.time_taken));

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,0 +1,347 @@
+require('isomorphic-fetch');
+const NodeHelper = require('node_helper');
+const moment = require('moment');
+const fs = require('fs');
+const path = require('path');
+const Dropbox = require('dropbox').Dropbox;
+
+const IMG_FOLDER = path.join(__dirname, 'image_cache');
+const ERR_MESSAGE = 'The Dropbox folder you chose doesn\'t exist or is empty. Please try a different one.';
+
+module.exports = NodeHelper.create({
+
+    start: function() {
+
+        console.log('Starting node_helper for module [' + this.name + ']');
+
+        this.config = {};
+        this.files = []; // use to store all available files we've pulled
+
+    },
+
+    initialize: function(config) {
+
+        this.config = config;
+        this.extensions = ['.jpg', '.jpeg', '.png', '.gif'];
+        this.dbx = new Dropbox({ fetch, accessToken: this.config.token });
+        this.initialLoadDone = false; // triggered after the initial load of data
+        this.filesToSave = 25;
+
+        // see if image folder exists, otherwise create it
+        if (!fs.existsSync(IMG_FOLDER)) {
+            fs.mkdirSync(IMG_FOLDER);
+        }
+
+        // we only want to pull fresh dropbox data every 12 hours
+        this.lastDataPull = Date.now();
+        this.lastDataPullError = false;
+    },
+
+    getData: function() {
+        // get data from dropbox
+
+        if (this.timer) {
+            clearTimeout(this.timer);
+        }
+
+        const self = this;
+
+        this.files = [];
+
+        const resultsMaxPerExtension = 200;        // number of results per file extension
+        const resultsMax = 200;                    // number of new results we want total
+        const extLength = this.extensions.length;  // how many file extensions to search for
+
+        let extSearched = 0;                       // how many file extensions we've searched
+        let stopAdding = false;                    // we've either found resultsMax or reached the end of our search results
+        let filesAdded = 0;                        // how many new files we've added to this.files
+
+        // if the path isn't empty, it needs to start with a `/`
+        let path = this.config.folder ? this.config.folder.toLowerCase().trim() : '';
+        if (path !== '') {
+            if (path.charAt(0) !== '/') {
+                path = '/' + path;
+            }
+        }
+
+        const fileSearch = (path, ext, start) => {
+            self.dbx.filesSearch({
+                path,
+                query: ext,
+                start,
+                max_results: resultsMaxPerExtension,
+                mode: 'filename'
+            }).then((result) => {
+
+                const matches = result.matches;
+                if ((matches) && (matches.length > 0)) {
+                    for (const j in matches) {
+
+                        const file = matches[j];
+
+                        // only add files that don't already exist in this.files
+                        if ((!stopAdding) && (!self.fileExists(file.metadata.id))) {
+
+                            const fileObj = {
+                                name: file.metadata.name,
+                                path: file.metadata.path_lower,
+                                id: file.metadata.id,
+                                size: file.metadata.size,
+                                width: 0,
+                                height: 0,
+                                latitude: 0,
+                                longitude: 0,
+                                time_taken: new moment(file.metadata.client_modified).format('x'),
+                                orientation: 1,
+                                thumbnail: '',
+                                loaded: false,
+                                saved: false,
+                                error: false
+                            };
+
+                            self.files.push(fileObj);
+                            filesAdded++
+
+                            if (filesAdded >= resultsMax) {
+                                stopAdding = true;
+                                self.sortData();
+                                break;
+                            }
+                        }
+
+                    }
+                }
+
+                extSearched++;
+
+                if ((!stopAdding) && (extSearched === extLength)) {
+                    // we've searched all file extensions and reached the end
+                    self.sortData();
+                }
+
+            }).catch((err) => {
+                extSearched++;
+                if ((extSearched === extLength) && (filesAdded < 1)) {
+                    // we've searched with all file extensions and found no files
+                    self.sendSocketNotification('MMM_DROPBOX_ERROR', ERR_MESSAGE);
+                }
+            });
+        };
+
+        // search with all file extensions
+        for (const i in this.extensions) {
+            if (!stopAdding) {
+                const ext = this.extensions[i];
+                fileSearch(path, ext, 0);
+            }
+        }
+
+    },
+
+    sortData: function() {
+
+        // sort this.files based on time_taken property (newest first)
+        this.files.sort((a, b) => b.time_taken.localeCompare(a.time_taken));
+
+        // get thumbnails
+        this.getThumbnails();
+
+    },
+
+    getThumbnails: function() {
+
+        const self = this;
+
+        const filesToDownload = [];                // temporary array for batch download of thumbnails
+        const filesToDownloadError = [];           // temporary array for thumbnail errors
+
+        let filesDownloaded = 0;                   // how many files we've downloaded
+        let stopDownloading = false;               // when to stop parsing
+
+        if (this.files.length > 0) {
+
+            // set up array op files to be downloaded
+
+            for (const i in this.files) {
+
+                if ((!this.files[i].loaded) && (!this.files[i].error)) {
+                    if (filesToDownload.length < this.filesToSave) {
+                        filesToDownload.push({
+                            path: this.files[i].path,
+                            size: 'w480h320',
+                            mode: 'strict'
+                        });
+                        // push to error array as well, so we have something to compare
+                        // against if there's a download error
+                        filesToDownloadError.push(this.files[i].id);
+                    } else {
+                        break;
+                    }
+                }
+
+            }
+
+            // batch download thumbnails
+
+            if (filesToDownload.length > 0) {
+
+                self.dbx.filesGetThumbnailBatch({
+                    entries: filesToDownload
+                }).then((data) => {
+
+                    if (data.entries.length > 0) {
+
+                        for (const j in data.entries) {
+
+                            const image = data.entries[j];
+                            const success = (image['.tag'] === 'success');
+                            let imageId = 0;
+
+                            if (success) {
+                                // success loading image
+                                imageId = image.metadata.id;
+
+                            } else {
+                                // failure loading image
+                                imageId = filesToDownloadError[j];
+                            }
+
+                            // find file in this.files using the id of the image
+                            // this returns the original object, so any changes we make will be reflected in this.files
+                            // this also doesn't work in IE; too bad
+
+                            const file = self.files.find(x => x.id === imageId);
+
+                            if (file) {
+                                if (success) {
+
+                                    const fileMedia = image.metadata.media_info;
+
+                                    // update file properties
+                                    file.loaded = true;
+                                    file.thumbnail = image.thumbnail; // base64-encoded thumbnail data
+
+                                    // check media data
+                                    if ((fileMedia) && (fileMedia.metadata)) {
+
+                                        if (fileMedia.metadata.dimensions) {
+                                            file.width = fileMedia.metadata.dimensions.width;
+                                            file.height = fileMedia.metadata.dimensions.height;
+                                        }
+
+                                        if (fileMedia.metadata.location) {
+                                            file.latitude = fileMedia.metadata.location.latitude;
+                                            file.longitude = fileMedia.metadata.location.longitude;
+                                        }
+
+                                        if (fileMedia.metadata.time_taken) {
+                                            file.time_taken = new moment(fileMedia.metadata.time_taken).format('x');
+                                        }
+                                    }
+
+                                } else {
+                                    // want to make sure this file doesn't get loaded again
+                                    file.loaded = false;
+                                    file.error = true;
+                                }
+
+                            }
+
+                        }
+                    }
+
+                    self.saveThumbnails();
+
+                }).catch((err) => {
+                    // swallow errors
+                    self.saveThumbnails();
+                });
+
+            } else {
+
+                // no new images to download
+                self.saveThumbnails();
+
+            }
+
+        } else {
+            self.sendSocketNotification('MMM_DROPBOX_ERROR', ERR_MESSAGE);
+        }
+
+    },
+
+    saveThumbnails: function() {
+        // this saves the image files into a image_cache directory
+        // and also returns the image data to the module
+
+        let filesSaved = 0; // how many files we've saved
+        let filesChecked = 0; // how many files we've gone through
+
+        if (this.files.length > 0) {
+
+            for (const i in this.files) {
+
+                filesChecked++;
+
+                const file = this.files[i];
+                const filePath = path.join(IMG_FOLDER, file.name);
+
+                if ((file.loaded) && (!file.saved)) {
+
+                    if (!fs.existsSync(filePath)) {
+                        // only write the file if it doesn't already exist
+                        fs.writeFileSync(filePath, file.thumbnail, {encoding: 'base64'});
+                    }
+
+                    file.saved = true;
+                    file.thumbnail = ''; // we don't want to save this
+                    filesSaved++;
+
+                }
+
+                // we only save 25 files in every update
+                if (filesSaved > (this.filesToSave - 1)) {
+                    this.notifyModuleSaveDone();
+                    break;
+                } else if (filesChecked === this.files.length) {
+                    // no more files to save
+                    this.notifyModuleSaveDone();
+                }
+
+            }
+
+        } else {
+            this.sendSocketNotification('MMM_DROPBOX_ERROR', ERR_MESSAGE);
+        }
+
+    },
+
+    notifyModuleSaveDone: function() {
+
+        var self = this;
+        clearTimeout(this.timer);
+
+        this.sendSocketNotification('MMM_DROPBOX_FILES', this.files);
+
+        this.timer = setTimeout(() => {
+            self.sortData();
+        }, self.config.updateInterval);
+
+    },
+
+    fileExists: function(id) {
+        return this.files.some((ele) => ele.id === id);
+    },
+
+    socketNotificationReceived: function(notification, payload) {
+
+        if (notification === 'MMM_DROPBOX_INIT') {
+            this.initialize(payload);
+
+        } else if (notification === 'MMM_DROPBOX_GET') {
+            this.getData();
+        }
+
+    }
+
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mmm-dropbox",
+  "version": "1.0.0",
+  "description": "Dropbox module for MagicMirror",
+  "main": "mmm-dropbox.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/michael5r/mmm-dropbox.git"
+  },
+  "engines": {
+    "node": ">=8.9.0"
+  },
+  "author": "Michael Schmidt",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/michael5r/mmm-dropbox/issues"
+  },
+  "homepage": "https://github.com/michael5r/mmm-dropbox#readme",
+  "dependencies": {
+    "dropbox": "^4.0.14",
+    "isomorphic-fetch": "^2.2.1"
+  }
+}


### PR DESCRIPTION
The `mmm-dropbox` module is a [MagicMirror](https://github.com/MichMich/MagicMirror) addon.

This module takes images from a [Dropbox](https://www.dropbox.com) folder, scales & formats them nicely, and then displays them in organized rows on your Magic Mirror.

This module has a very specific target audience - my wife. She wanted an easy way for her & our daughter to upload photos of our cat to Dropbox and then see them on her mirror. So ... if you're looking for a module with endless configurations, tons of design options and the ability to handle videos, well, this isn't it. Sorry.

What this module does allow you to do, however, is to:
- pick a Dropbox folder to load images (`.jpg`, `.jpeg`, `.gif` and `.png`) from
- control how many rows of images you'd like to see
- control the base number of images you'd like to see per row
- select whether the images are randomly sorted or displayed newest first
- gaze in amazement at endless cat photos nicely lined up next to each other