### PR TITLE
1.0.1: Update Dropbox calls

### DIFF
--- a/mmm-dropbox.js
+++ b/mmm-dropbox.js
@@ -22,7 +22,7 @@ Module.register('mmm-dropbox', {
         updateInterval: 5 * 60 * 1000,          // every 5 minutes
         animationSpeed: 2 * 1000,
         initialLoadDelay: 0,
-        version: '1.0.0'
+        version: '1.0.1'
     },
 
     getStyles: function() {

--- a/node_helper.js
+++ b/node_helper.js
@@ -100,6 +100,37 @@ module.exports = NodeHelper.create({
                                 error: false
                             };
 
+                            // get meta data
+
+                            self.dbx.filesGetMetadata({
+                                path: fileObj.path,
+                                include_media_info: true
+                            }).then((fileMetaData) => {
+
+                                if ((fileMetaData.media_info) && (fileMetaData.media_info.metadata)) {
+
+                                    const fileMetaDataData = fileMetaData.media_info.metadata;
+
+                                    if (fileMetaDataData.dimensions) {
+                                        fileObj.width = fileMetaDataData.dimensions.width;
+                                        fileObj.height = fileMetaDataData.dimensions.height;
+                                    }
+
+                                    if (fileMetaDataData.location) {
+                                        fileObj.latitude = fileMetaDataData.location.latitude;
+                                        fileObj.longitude = fileMetaDataData.location.longitude;
+                                    }
+
+                                    if (fileMetaDataData.time_taken) {
+                                        fileObj.time_taken = new moment(fileMetaDataData.time_taken).format('x');
+                                    }
+
+                                }
+
+                            }).catch((err) => {
+                                // swallow errors
+                            });
+
                             self.files.push(fileObj);
                             filesAdded++
 
@@ -225,29 +256,9 @@ module.exports = NodeHelper.create({
                             if (file) {
                                 if (success) {
 
-                                    const fileMedia = image.metadata.media_info;
-
                                     // update file properties
                                     file.loaded = true;
                                     file.thumbnail = image.thumbnail; // base64-encoded thumbnail data
-
-                                    // check media data
-                                    if ((fileMedia) && (fileMedia.metadata)) {
-
-                                        if (fileMedia.metadata.dimensions) {
-                                            file.width = fileMedia.metadata.dimensions.width;
-                                            file.height = fileMedia.metadata.dimensions.height;
-                                        }
-
-                                        if (fileMedia.metadata.location) {
-                                            file.latitude = fileMedia.metadata.location.latitude;
-                                            file.longitude = fileMedia.metadata.location.longitude;
-                                        }
-
-                                        if (fileMedia.metadata.time_taken) {
-                                            file.time_taken = new moment(fileMedia.metadata.time_taken).format('x');
-                                        }
-                                    }
 
                                 } else {
                                     // want to make sure this file doesn't get loaded again

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-dropbox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Dropbox module for MagicMirror",
   "main": "mmm-dropbox.js",
   "repository": {
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/michael5r/mmm-dropbox#readme",
   "dependencies": {
-    "dropbox": "^4.0.14",
+    "dropbox": "^4.0.30",
     "isomorphic-fetch": "^2.2.1"
   }
 }


### PR DESCRIPTION
Dropbox's API changed, so `filesGetThumbnailBatch` no longer returns a file's `media_info` (which includes width, height, location, etc).

Instead I'm forced to do individual calls to `filesGetMetadata` to get this data - sucky.